### PR TITLE
Fix tray icon next message

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -228,7 +228,7 @@ void send_to_socket(const std::string& message)
 
 void on_next()
 {
-    std::cout << "Next action triggered from main" << std::endl;
+    std::cout << "Next action triggered from tray icon" << std::endl;
     send_to_socket("next");
 }
 


### PR DESCRIPTION
## Summary
- correct the `on_next` message to clarify it's triggered from the tray icon

## Testing
- `grep -n "Next action" -n main.cpp`

------
https://chatgpt.com/codex/tasks/task_e_68424457a2a0832e8759b082d36de0ec